### PR TITLE
Make sure Follower#following? returns a boolean value

### DIFF
--- a/lib/partisan/follower.rb
+++ b/lib/partisan/follower.rb
@@ -47,7 +47,7 @@ module Partisan
     def following?(resource)
       return false if self == resource
 
-      fetch_follows(resource).exists?
+      !!fetch_follows(resource).exists?
     end
 
     # Get all follows record related to a resource


### PR DESCRIPTION
Since `ActiveRecord::Relation#exists?` returns either `1` or `nil`, let’s use `!!` to make sure we convert it to a boolean value.
