### PR TITLE
Use a common method to inject into ActiveRecord

### DIFF
--- a/lib/partisan.rb
+++ b/lib/partisan.rb
@@ -8,8 +8,19 @@ require "partisan/follower"
 require "partisan/followable"
 
 module Partisan
-
   include Partisan::FollowHelper
+
+  def self.inject_into_active_record
+    @inject_into_active_record ||= Proc.new do
+      def self.acts_as_follower
+        self.send :include, Partisan::Follower
+      end
+
+      def self.acts_as_followable
+        self.send :include, Partisan::Followable
+      end
+    end
+  end
 end
 
 require 'partisan/railtie' if defined?(Rails) && Rails::VERSION::MAJOR >= 3

--- a/lib/partisan/railtie.rb
+++ b/lib/partisan/railtie.rb
@@ -4,15 +4,7 @@ require 'rails'
 module Partisan
   class Railtie < Rails::Railtie
     initializer "follows.active_record" do |app|
-      ActiveSupport.on_load :active_record do
-        def self.acts_as_follower
-          self.send :include, Partisan::Follower
-        end
-
-        def self.acts_as_followable
-          self.send :include, Partisan::Followable
-        end
-      end
+      ActiveSupport.on_load :active_record, {}, &Partisan.inject_into_active_record
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,9 @@ require 'partisan'
 
 # Require our macros and extensions
 Dir[File.expand_path('../../spec/support/macros/*.rb', __FILE__)].map(&method(:require))
-Dir[File.expand_path('../../spec/support/extensions/*.rb', __FILE__)].map(&method(:require))
 
+# Inject our methods into ActiveRecord (like our railtie does)
+ActiveRecord::Base.class_eval(&Partisan.inject_into_active_record)
 
 RSpec.configure do |config|
   # Include our macros

--- a/spec/support/extensions/active_record.rb
+++ b/spec/support/extensions/active_record.rb
@@ -1,9 +1,0 @@
-class ActiveRecord::Base
-  def self.acts_as_follower
-    self.send :include, Partisan::Follower
-  end
-
-  def self.acts_as_followable
-    self.send :include, Partisan::Followable
-  end
-end


### PR DESCRIPTION
Instead of having duplicate code (in `lib` and `spec`) to inject our methods into `ActiveRecord`, let’s use the same pattern we used in [emotions](https://github.com/mirego/emotions) and use an `inject_into_active_record` method in both places.
