### PR TITLE
Rename Follower#following? to #follows?

### DIFF
--- a/lib/partisan/follower.rb
+++ b/lib/partisan/follower.rb
@@ -48,11 +48,12 @@ module Partisan
     #   @user.following?(@team)
     #
     # @return (Boolean)
-    def following?(resource)
+    def follows?(resource)
       return false if self == resource
 
       !!fetch_follows(resource).exists?
     end
+    alias_method :following?, :follows?
 
     # Get all follows record related to a resource
     #

--- a/spec/partisan/follower_spec.rb
+++ b/spec/partisan/follower_spec.rb
@@ -49,11 +49,11 @@ describe Partisan::Follower do
       it { expect{user.unfollow band}.to change{Partisan::Follow.last}.to(nil) }
     end
 
-    describe :following? do
+    describe :follows? do
       let(:band2) { Band.create }
 
-      it { expect(user.following? band).to be_true }
-      it { expect(user.following? band2).to be_false }
+      it { expect(user.follows? band).to be_true }
+      it { expect(user.follows? band2).to be_false }
     end
 
     describe :following_by_type do
@@ -153,9 +153,10 @@ describe Partisan::Follower do
   end
 
   describe :AliasMethods do
-    subject { User.create }
+    subject { User.new }
 
     it { should respond_to :start_following }
     it { should respond_to :stop_following }
+    it { should respond_to :following? }
   end
 end


### PR DESCRIPTION
If we want to stay consistent with our method names, I think we need to have a `follows?` method instead of `following?`.

We’ll now have three similarly-named methods (with their alias):
- `#follow` (`#start_following`)
- `#unfollow` (`#stop_following`)
- `#follows?`(`#following?`)
