### PR TITLE
Use a “real” model and inject our Follow behavior into it

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ And then execute
 $ bundle
 ```
 
-Run the migration to add the `follows` table:
+Run the migration to add the `follows` table and the `Follow` model:
 
 ```bash
 $ rails generate partisan:install

--- a/lib/generators/partisan/install_generator.rb
+++ b/lib/generators/partisan/install_generator.rb
@@ -20,6 +20,10 @@ module Partisan
       def create_migration_file
         migration_template 'migration.rb', 'db/migrate/add_follows_migration.rb'
       end
+
+      def create_model_file
+        template "model.rb", "app/models/follow.rb"
+      end
     end
   end
 end

--- a/lib/generators/partisan/templates/model.rb
+++ b/lib/generators/partisan/templates/model.rb
@@ -1,0 +1,3 @@
+class Follow < ActiveRecord::Base
+  acts_as_follow
+end

--- a/lib/partisan.rb
+++ b/lib/partisan.rb
@@ -19,6 +19,10 @@ module Partisan
       def self.acts_as_followable
         self.send :include, Partisan::Followable
       end
+
+      def self.acts_as_follow
+        self.send :include, Partisan::Follow
+      end
     end
   end
 end

--- a/lib/partisan/followable.rb
+++ b/lib/partisan/followable.rb
@@ -6,7 +6,7 @@ module Partisan
     include Partisan::FollowHelper
 
     included do
-      has_many :followings, as: :followable, class_name: 'Partisan::Follow', dependent: :destroy
+      has_many :followings, as: :followable, class_name: 'Follow', dependent: :destroy
       define_model_callbacks :being_followed
       define_model_callbacks :being_unfollowed
       attr_accessor :about_to_be_followed_by, :just_followed_by, :about_to_be_unfollowed_by, :just_unfollowed_by

--- a/lib/partisan/follower.rb
+++ b/lib/partisan/follower.rb
@@ -5,7 +5,7 @@ module Partisan
     include Partisan::FollowHelper
 
     included do
-      has_many :follows, as: :follower, class_name: 'Partisan::Follow', dependent: :destroy
+      has_many :follows, as: :follower, class_name: 'Follow', dependent: :destroy
       define_model_callbacks :follow
       define_model_callbacks :unfollow
       attr_accessor :about_to_follow, :just_followed, :about_to_unfollow, :just_unfollowed
@@ -17,7 +17,7 @@ module Partisan
     #
     #   @user.follow(@team)
     #
-    # @return (Partisan::Follow)
+    # @return (Follow)
     def follow(resource)
       return if self == resource
 
@@ -32,7 +32,7 @@ module Partisan
     #
     #   @user.unfollow(@team)
     #
-    # @return (Partisan::Follow) || nil
+    # @return (Follow) || nil
     def unfollow(resource)
       return if self == resource
 
@@ -61,7 +61,7 @@ module Partisan
     #
     #   @user.fetch_follows(@team)
     #
-    # @return [Partisan::Follow, ...]
+    # @return [Follow, ...]
     def fetch_follows(resource)
       follows.where followable_id: resource.id, followable_type: parent_class_name(resource)
     end

--- a/spec/partisan/follower_spec.rb
+++ b/spec/partisan/follower_spec.rb
@@ -41,12 +41,12 @@ describe Partisan::Follower do
     end
 
     describe :follow do
-      it { expect(Partisan::Follow.last.follower_id).to eq user.id }
-      it { expect(Partisan::Follow.last.followable_id).to eq band.id }
+      it { expect(Follow.last.follower_id).to eq user.id }
+      it { expect(Follow.last.followable_id).to eq band.id }
     end
 
     describe :unfollow do
-      it { expect{user.unfollow band}.to change{Partisan::Follow.last}.to(nil) }
+      it { expect{user.unfollow band}.to change{Follow.last}.to(nil) }
     end
 
     describe :follows? do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ RSpec.configure do |config|
 
     # Run our migration
     run_default_migration
+
+    spawn_model 'Follow', ActiveRecord::Base do
+      acts_as_follow
+    end
   end
 
   config.after(:each) do


### PR DESCRIPTION
This pull request converts `Partisan::Follow` from a class to a module that we can inject into a custom `Follow` class. Everything else stays the same.

We already do the same thing in [parole](https://github.com/mirego/parole) and [camaraderie](https://github.com/mirego/parole).
