### PR TITLE
Upgrade RSpec and Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 1.9.3
 
 gemfile:
+  - gemfiles/Gemfile.activerecord-4.1
   - gemfiles/Gemfile.activerecord-4.0
   - gemfiles/Gemfile.activerecord-3.2.x
 

--- a/gemfiles/Gemfile.activerecord-4.1
+++ b/gemfiles/Gemfile.activerecord-4.1
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 4.1.0'

--- a/partisan.gemspec
+++ b/partisan.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'sqlite3'
 end

--- a/spec/partisan/followable_spec.rb
+++ b/spec/partisan/followable_spec.rb
@@ -31,8 +31,8 @@ describe Partisan::Followable do
     end
 
     describe :followed_by? do
-      it { expect(band.followed_by? user).to be_true }
-      it { expect(concert.followed_by? user).to be_false }
+      it { expect(band.followed_by? user).to be_truthy }
+      it { expect(concert.followed_by? user).to be_falsey }
     end
 
     describe :followers_by_type do
@@ -62,8 +62,8 @@ describe Partisan::Followable do
     end
 
     describe :respond_to? do
-      it { expect(band.respond_to?(:user_followers)).to be_true }
-      it { expect(band.respond_to?(:users_follower_ids)).to be_true }
+      it { expect(band.respond_to?(:user_followers)).to be_truthy }
+      it { expect(band.respond_to?(:users_follower_ids)).to be_truthy }
     end
 
     describe :update_follow_counter do

--- a/spec/partisan/follower_spec.rb
+++ b/spec/partisan/follower_spec.rb
@@ -52,8 +52,8 @@ describe Partisan::Follower do
     describe :follows? do
       let(:band2) { Band.create }
 
-      it { expect(user.follows? band).to be_true }
-      it { expect(user.follows? band2).to be_false }
+      it { expect(user.follows? band).to be_truthy }
+      it { expect(user.follows? band2).to be_falsey }
     end
 
     describe :following_by_type do
@@ -89,8 +89,8 @@ describe Partisan::Follower do
     end
 
     describe :respond_to? do
-      it { expect(user.respond_to?(:following_bands)).to be_true }
-      it { expect(user.respond_to?(:following_band_ids)).to be_true }
+      it { expect(user.respond_to?(:following_bands)).to be_truthy }
+      it { expect(user.respond_to?(:following_band_ids)).to be_truthy }
     end
   end
 

--- a/spec/support/macros/rails_macros.rb
+++ b/spec/support/macros/rails_macros.rb
@@ -1,9 +1,13 @@
 module RailsMacros
+  # NOTE: This method is not fun to maintain but we need it to make sure
+  # Partisan methods return *real* not-loaded ActiveRecord relations
   def relation_class(klass)
     if ActiveRecord::VERSION::MAJOR == 3
       ActiveRecord::Relation
-    else
+    elsif [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR] == [4, 0]
       "ActiveRecord::Relation::ActiveRecord_Relation_#{klass.name}".constantize
+    else
+      "#{klass.name}::ActiveRecord_Relation".constantize
     end
   end
 end


### PR DESCRIPTION
- We’re now freezing RSpec version in the gemspec
- We now test for Rails 4.1
- The tests have been adjusted to work with the new Rails relation classes
