### PR TITLE
Add uniqueness index for follows

### DIFF
--- a/lib/generators/partisan/templates/migration.rb
+++ b/lib/generators/partisan/templates/migration.rb
@@ -7,8 +7,9 @@ class AddFollowsMigration < ActiveRecord::Migration
       t.timestamps null: false
     end
 
-    add_index :follows, ['follower_id', 'follower_type'],     name: 'index_partisan_followers'
+    add_index :follows, ['follower_id', 'follower_type'], name: 'index_partisan_followers'
     add_index :follows, ['followable_id', 'followable_type'], name: 'index_partisan_followables'
+    add_index :follows, ['follower_id', 'follower_type', 'followable_id', 'follower_type'], name: 'index_partisan_unique_follow', unique: true
   end
 
   def down


### PR DESCRIPTION
As noted by @amnesia7 in #16, we didn’t have any kind of mechanism to prevent duplicate `Follow` records to be created.

Now we do.