### PR TITLE
Add support for Rails 5 ApplicationRecord pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ sudo: false
 language: ruby
 
 rvm:
-  - 2.2
-  - 2.1
-  - 2.0
+  - 2.2.2
 
 gemfile:
+  - gemfiles/Gemfile.activerecord-5.0
   - gemfiles/Gemfile.activerecord-4.2
   - gemfiles/Gemfile.activerecord-4.1
 

--- a/gemfiles/Gemfile.activerecord-5.0
+++ b/gemfiles/Gemfile.activerecord-5.0
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 5.0.0'

--- a/lib/partisan/helper.rb
+++ b/lib/partisan/helper.rb
@@ -9,7 +9,7 @@ module Partisan
       klass ||= obj.object.class if obj.respond_to?(:object) && obj.object.class < ActiveRecord::Base
 
       # In case we’re using STI, loop back until we find the top-level ActiveRecord model
-      klass = klass.superclass while klass.superclass != ActiveRecord::Base
+      klass = klass.superclass while !klass.superclass.abstract_class && klass.superclass != ActiveRecord::Base
 
       klass.name
     end

--- a/spec/partisan/helper_spec.rb
+++ b/spec/partisan/helper_spec.rb
@@ -24,6 +24,18 @@ describe Partisan::Helper do
         it { expect(parent_class_name).to eql 'Article' }
       end
 
+      context 'with object that inherits from abstract class' do
+        let(:object) do
+          spawn_model('ApplicationRecord', ActiveRecord::Base) do
+            self.abstract_class = true
+          end
+
+          spawn_model('Article', ApplicationRecord).new
+        end
+
+        it { expect(parent_class_name).to eql 'Article' }
+      end
+
       context 'with a presented record object' do
         let(:presenter_class) do
           Class.new(::SimpleDelegator) do


### PR DESCRIPTION
This fixes #20.

I think with this fix we should be able to release `partisan-0.5` and bump the `activerecord`  requirement to `>= 5.0.0` (instead of `>= 3.0.0`). Older `partisan` versions will continue to work just fine with Rails 3 and 4.

@simonprev @garno What do you think?