### PR TITLE
Fix Column Name On Migration

### DIFF
--- a/lib/generators/partisan/templates/migration.rb
+++ b/lib/generators/partisan/templates/migration.rb
@@ -9,7 +9,7 @@ class AddFollowsMigration < ActiveRecord::Migration
 
     add_index :follows, ['follower_id', 'follower_type'], name: 'index_partisan_followers'
     add_index :follows, ['followable_id', 'followable_type'], name: 'index_partisan_followables'
-    add_index :follows, ['follower_id', 'follower_type', 'followable_id', 'follower_type'], name: 'index_partisan_unique_follow', unique: true
+    add_index :follows, ['follower_id', 'follower_type', 'followable_id', 'followable_type'], name: 'index_partisan_unique_follow', unique: true
   end
 
   def down


### PR DESCRIPTION
This problem didn't show itself as a problem until I added a self referential table, ie Users following other Users. If someone followed a user, and that user tried to follow them back, a unique constraint error on the db was triggered.